### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ version 1.1
 * 天气的城市选择
 
 
-#Thanks
+# Thanks
 
 * [butterknife](https://github.com/JakeWharton/butterknife)
 * [SuperToasts](https://github.com/JohnPersano/SuperToasts)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
